### PR TITLE
Fix "How Playorder Works" section overflow on extra-small screens

### DIFF
--- a/app/assets/stylesheets/style.css
+++ b/app/assets/stylesheets/style.css
@@ -177,8 +177,8 @@ a.circle { color: transparent; } /* IE fix: removes blue border */
 /* index - how it works */
 .hiw-cover {
   background-color: #f5f5f5;
-	padding-top: 40px;
-  height: 440px;
+  /*padding-top: 40px;*/
+  /*height: 440px;*/
 }
 .hiw {
   text-align: center;
@@ -189,7 +189,8 @@ a.circle { color: transparent; } /* IE fix: removes blue border */
 }
 .how-it-works li {
   display: inline-block;
-  margin: 0 100px 20px 0;
+  /*margin: 0 100px 20px 0;*/
+  padding: 0 50px 20px 50px;
 }
 
 .how-it-works li h2 {

--- a/app/views/root/index.html.erb
+++ b/app/views/root/index.html.erb
@@ -75,24 +75,26 @@
 <!-- how it work -->
 <div class="hiw-cover">
   <section class="container hiw">
-    <h2>HOW PLAYORDER WORKS</h2>
-    <ul class='how-it-works'>
-      <li>
-        <%= image_tag "index/hiw-1.png" %>
-        <h2>1. Discover Gifts</h2>
-        <p>Let&#39;s discover much-valued gifts</p>
-      </li>
-      <li>
-        <%= image_tag "index/hiw-2.png" %>
-        <h2>2. Share Payment</h2>
-        <p>You can share and pay selection</p>
-      </li>
-      <li>
-        <%= image_tag "index/hiw-3.png" %>
-        <h2>3. Deliver Experience</h2>
-        <p>Not product, but experience</p>
-      </li>
-    </ul>
+    <div class="row">
+      <h2>HOW PLAYORDER WORKS</h2>
+      <ul class='how-it-works'>
+        <li>
+          <%= image_tag "index/hiw-1.png" %>
+          <h2>1. Discover Gifts</h2>
+          <p>Let&#39;s discover much-valued gifts</p>
+        </li>
+        <li>
+          <%= image_tag "index/hiw-2.png" %>
+          <h2>2. Share Payment</h2>
+          <p>You can share and pay selection</p>
+        </li>
+        <li>
+          <%= image_tag "index/hiw-3.png" %>
+          <h2>3. Deliver Experience</h2>
+          <p>Not product, but experience</p>
+        </li>
+      </ul>
+    </div>
   </section>
 </div>
 


### PR DESCRIPTION
The issue:
![screen shot 2016-04-07 at 3 45 11 pm](https://cloud.githubusercontent.com/assets/13649002/14369214/065f6bfe-fcd8-11e5-875b-f41708ddf532.png)

The solution:
![screen shot 2016-04-07 at 3 44 56 pm](https://cloud.githubusercontent.com/assets/13649002/14369218/0c2da0fa-fcd8-11e5-9d94-42f1ffff221a.png)

Because the height was fixed for that section, on extra-small screens the content overflowed to the footer section. To fix that, everything was placed under a bootstrap .row and then the fixed height property was removed. 

Additionally, only having a 100px margin-right was preventing the li items from being centered in the section. To fix that, equal padding was applied to both sides of the li instead of a margin.