### PR TITLE
Activate and add indicators to main carousel

### DIFF
--- a/app/assets/stylesheets/style.css
+++ b/app/assets/stylesheets/style.css
@@ -177,8 +177,8 @@ a.circle { color: transparent; } /* IE fix: removes blue border */
 /* index - how it works */
 .hiw-cover {
   background-color: #f5f5f5;
-	padding-top: 40px;
-  height: 440px;
+  /*padding-top: 40px;*/
+  /*height: 440px;*/
 }
 .hiw {
   text-align: center;
@@ -189,7 +189,8 @@ a.circle { color: transparent; } /* IE fix: removes blue border */
 }
 .how-it-works li {
   display: inline-block;
-  margin: 0 100px 20px 0;
+  /*margin: 0 100px 20px 0;*/
+  padding: 0 50px 20px 50px;
 }
 
 .how-it-works li h2 {

--- a/app/views/root/index.html.erb
+++ b/app/views/root/index.html.erb
@@ -1,36 +1,39 @@
 
-<!-- Wrapper for slides -->
-<div class="carousel-inner" role="listbox">
-  <div class="item active">
-    <%= image_tag "index/carousel-flower.png" %>
-    <div class="carousel-caption">
-      <h1>Celebratie with<br>custom made flower</h1>
-      <div class="btn btn-white btn-ghost">Learn More</div>
+<div class="container">
+  <div class="row">
+    <!-- Wrapper for slides -->
+    <div class="carousel-inner" role="listbox">
+      <div class="item active">
+        <%= image_tag "index/carousel-flower.png" %>
+        <div class="carousel-caption">
+          <h1>Celebrate with<br>custom made flowers</h1>
+          <div class="btn btn-white btn-ghost">Learn More</div>
+        </div>
+      </div>
+      <div class="item">
+        <%= image_tag "index/carousel-flower.png" %>
+        <div class="carousel-caption">
+          <h1>Celeberate with<br>custom made cookie</h1>
+          <div class="btn btn-white btn-ghost">Learn More</div>
+        </div>
+      </div>
+      <div class="item">
+        <%= image_tag "index/carousel-flower.png" %>
+        <div class="carousel-caption">
+          <h1>Celeberate with<br>custom made arts</h1>
+          <div class="btn btn-white btn-ghost">Learn More</div>
+        </div>
+      </div>
+      <div class="item">
+        <%= image_tag "index/carousel-flower.png" %>
+        <div class="carousel-caption">
+          <h1>Celeberate with<br>custom made sake</h1>
+          <div class="btn btn-white btn-ghost">Learn More</div>
+        </div>
+      </div>
     </div>
-  </div>
-  <div class="item">
-    <%= image_tag "index/carousel-flower.png" %>
-    <div class="carousel-caption">
-      <h1>Celeberate with<br>custom made cookie</h1>
-      <div class="btn btn-white btn-ghost">Learn More</div>
-    </div>
-  </div>
-  <div class="item">
-    <%= image_tag "index/carousel-flower.png" %>
-    <div class="carousel-caption">
-      <h1>Celeberate with<br>custom made arts</h1>
-      <div class="btn btn-white btn-ghost">Learn More</div>
-    </div>
-  </div>
-  <div class="item">
-    <%= image_tag "index/carousel-flower.png" %>
-    <div class="carousel-caption">
-      <h1>Celeberate with<br>custom made sake</h1>
-      <div class="btn btn-white btn-ghost">Learn More</div>
-    </div>
-  </div>
-</div>
-
+  </div><!-- .row -->
+</div><!-- .container -->
 
 <!-- card index -->
 <section class="container card-roll">
@@ -67,32 +70,39 @@
 
 <section class="slider slider-index">
   <div class="jumbotron index-1">
-    <h1>Order the Gift<br>with Share Payment</h1>
-    <div class="btn btn-white btn-ghost">DISCOVER</div>
-  </div>
+    <div class="container">
+      <div class="row">
+        <h1>Order the Gift<br>with Share Payment</h1>
+        <div class="btn btn-white btn-ghost">DISCOVER</div>
+      </div>
+    </div><!-- .row -->
+  </div><!-- .container -->
 </section>
+
 
 <!-- how it work -->
 <div class="hiw-cover">
   <section class="container hiw">
-    <h2>HOW PLAYORDER WORKS</h2>
-    <ul class='how-it-works'>
-      <li>
-        <%= image_tag "index/hiw-1.png" %>
-        <h2>1. Discover Gifts</h2>
-        <p>Let&#39;s discover much-valued gifts</p>
-      </li>
-      <li>
-        <%= image_tag "index/hiw-2.png" %>
-        <h2>2. Share Payment</h2>
-        <p>You can share and pay selection</p>
-      </li>
-      <li>
-        <%= image_tag "index/hiw-3.png" %>
-        <h2>3. Deliver Experience</h2>
-        <p>Not product, but experience</p>
-      </li>
-    </ul>
+    <div class="row">
+      <h2>HOW PLAYORDER WORKS</h2>
+      <ul class='how-it-works'>
+        <li>
+          <%= image_tag "index/hiw-1.png" %>
+          <h2>1. Discover Gifts</h2>
+          <p>Let&#39;s discover much-valued gifts</p>
+        </li>
+        <li>
+          <%= image_tag "index/hiw-2.png" %>
+          <h2>2. Share Payment</h2>
+          <p>You can share and pay selection</p>
+        </li>
+        <li>
+          <%= image_tag "index/hiw-3.png" %>
+          <h2>3. Deliver Experience</h2>
+          <p>Not product, but experience</p>
+        </li>
+      </ul>
+    </div>
   </section>
 </div>
 
@@ -106,11 +116,15 @@
 </section>
 
 <!-- let's get started -->
-<section class="getstarted">
-  <h2>Let&#39;s Get Started!</h2>
-  <p>You can enjoy amazing order for gift or create custom gift.</p>
-  <ul>
-    <li><div class="btn btn-startorder">DISCOVER GIFT</div></li>
-    <li><div class="btn btn-startup">CREATE GIFT</div></li>
-  </ul>
-</section>
+<div class="container">
+  <div class="row">
+    <section class="getstarted">
+      <h2>Let&#39;s Get Started!</h2>
+      <p>You can enjoy amazing order for gift or create custom gift.</p>
+      <ul>
+        <li><div class="btn btn-startorder">DISCOVER GIFT</div></li>
+        <li><div class="btn btn-startup">CREATE GIFT</div></li>
+      </ul>
+    </section>
+  </div>
+</div>

--- a/app/views/root/index.html.erb
+++ b/app/views/root/index.html.erb
@@ -1,37 +1,51 @@
 
+<!-- Wrapper for slides -->
 <div class="container">
   <div class="row">
-    <!-- Wrapper for slides -->
-    <div class="carousel-inner" role="listbox">
-      <div class="item active">
-        <%= image_tag "index/carousel-flower.png" %>
-        <div class="carousel-caption">
-          <h1>Celebrate with<br>custom made flowers</h1>
-          <div class="btn btn-white btn-ghost">Learn More</div>
+    
+    <div id="#main-carousel" class="carousel slide" data-ride="carousel">
+
+      <!-- Indicators -->
+      <ol class="carousel-indicators">
+        <li data-target="#main-carousel" data-slide-to="0" class="active"></li>
+        <li data-target="#main-carousel" data-slide-to="1"></li>
+        <li data-target="#main-carousel" data-slide-to="2"></li>
+        <li data-target="#main-carousel" data-slide-to="3"></li>
+      </ol>
+
+      <!-- Carousel Slides -->
+      <div class="carousel-inner" role="listbox">
+        <div class="item active">
+          <%= image_tag "index/carousel-flower.png" %>
+          <div class="carousel-caption">
+            <h1>Celebrate with<br>custom made flowers</h1>
+            <div class="btn btn-white btn-ghost">Learn More</div>
+          </div>
+        </div>
+        <div class="item">
+          <%= image_tag "index/carousel-flower.png" %>
+          <div class="carousel-caption">
+            <h1>Celeberate with<br>custom made cookie</h1>
+            <div class="btn btn-white btn-ghost">Learn More</div>
+          </div>
+        </div>
+        <div class="item">
+          <%= image_tag "index/carousel-flower.png" %>
+          <div class="carousel-caption">
+            <h1>Celeberate with<br>custom made arts</h1>
+            <div class="btn btn-white btn-ghost">Learn More</div>
+          </div>
+        </div>
+        <div class="item">
+          <%= image_tag "index/carousel-flower.png" %>
+          <div class="carousel-caption">
+            <h1>Celeberate with<br>custom made sake</h1>
+            <div class="btn btn-white btn-ghost">Learn More</div>
+          </div>
         </div>
       </div>
-      <div class="item">
-        <%= image_tag "index/carousel-flower.png" %>
-        <div class="carousel-caption">
-          <h1>Celeberate with<br>custom made cookie</h1>
-          <div class="btn btn-white btn-ghost">Learn More</div>
-        </div>
-      </div>
-      <div class="item">
-        <%= image_tag "index/carousel-flower.png" %>
-        <div class="carousel-caption">
-          <h1>Celeberate with<br>custom made arts</h1>
-          <div class="btn btn-white btn-ghost">Learn More</div>
-        </div>
-      </div>
-      <div class="item">
-        <%= image_tag "index/carousel-flower.png" %>
-        <div class="carousel-caption">
-          <h1>Celeberate with<br>custom made sake</h1>
-          <div class="btn btn-white btn-ghost">Learn More</div>
-        </div>
-      </div>
-    </div>
+
+    </div><!-- #main-carousel -->
   </div><!-- .row -->
 </div><!-- .container -->
 

--- a/app/views/root/index.html.erb
+++ b/app/views/root/index.html.erb
@@ -25,21 +25,21 @@
         <div class="item">
           <%= image_tag "index/carousel-flower.png" %>
           <div class="carousel-caption">
-            <h1>Celeberate with<br>custom made cookie</h1>
+            <h1>Celebrate with<br>custom made cookie</h1>
             <div class="btn btn-white btn-ghost">Learn More</div>
           </div>
         </div>
         <div class="item">
           <%= image_tag "index/carousel-flower.png" %>
           <div class="carousel-caption">
-            <h1>Celeberate with<br>custom made arts</h1>
+            <h1>Celebrate with<br>custom made arts</h1>
             <div class="btn btn-white btn-ghost">Learn More</div>
           </div>
         </div>
         <div class="item">
           <%= image_tag "index/carousel-flower.png" %>
           <div class="carousel-caption">
-            <h1>Celeberate with<br>custom made sake</h1>
+            <h1>Celebrate with<br>custom made sake</h1>
             <div class="btn btn-white btn-ghost">Learn More</div>
           </div>
         </div>


### PR DESCRIPTION
Makes the main carousel work. Adds indicators to main carousel to that it will show which slide it is showing (The circles O O O O on the bottom center of the slide). Also fixes typo ("celebrate") in slider text.

![screen shot 2016-04-09 at 7 42 18 pm](https://cloud.githubusercontent.com/assets/13649002/14407822/74c5de48-fe8b-11e5-8db3-e0b7a3231591.png)

Note that the carousel was enclosed in a div whose id was #main-carousel with .carousel class and data-ide="carousel".

Additionally, you could also add controls (left and right) to the slider. Let me know if you would like me to add that in a different PR.

Also, you can control the carousel interval using JavaScript (jQuery):
```
$("#main-carousel").carousel( { interval: 2000 } ); // interval in milliseconds
```